### PR TITLE
Fix Threads package

### DIFF
--- a/build/cmake/Config.cmake.in
+++ b/build/cmake/Config.cmake.in
@@ -2,8 +2,8 @@
 
 set(package_deps @package_deps@)
 foreach(dep IN LISTS package_deps)
-    if(dep STREQUAL "OpenSSL")
-        find_package(OpenSSL REQUIRED)
+    if(dep STREQUAL "OpenSSL" OR dep STREQUAL "Threads")
+        find_package(${dep} REQUIRED)
     else()
         find_package(${dep} CONFIG REQUIRED)
     endif()


### PR DESCRIPTION
Recently got this error:

```
  Could not find a package configuration file provided by "Threads" with any
  of the following names:

    ThreadsConfig.cmake
    threads-config.cmake
```