### PR TITLE
Fix bug in TMemoryBuffer

### DIFF
--- a/lib/cpp/src/thrift/transport/TBufferTransports.h
+++ b/lib/cpp/src/thrift/transport/TBufferTransports.h
@@ -449,7 +449,7 @@ private:
   // Common initialization done by all constructors.
   void initCommon(uint8_t* buf, uint32_t size, bool owner, uint32_t wPos) {
 
-    maxBufferSize_ = std::numeric_limits<uint32_t>::max();
+    maxBufferSize_ = (std::numeric_limits<uint32_t>::max)();
 
     if (buf == NULL && size != 0) {
       assert(owner);


### PR DESCRIPTION
line 452 should be  maxBufferSize_ = (std::numeric_limits<uint32_t>::max)();
there are compilation problems on visual studio if not
there is an example of this pattern in line 335

I'm new to hunter so i do not know the necessary changes on hunter side. 
May be someone could enplane which modifications are needed to bring this tiny patch online